### PR TITLE
Add Ctrl+K cut line action

### DIFF
--- a/src/app/editor.rs
+++ b/src/app/editor.rs
@@ -181,6 +181,63 @@ impl App {
         }
     }
 
+    pub(crate) fn cut_line(&mut self) {
+        let Some(tab) = self.active_tab() else {
+            return;
+        };
+        let (row, _col) = tab.editor.cursor();
+        let lines = tab.editor.lines();
+        if lines.is_empty() || row >= lines.len() {
+            self.set_status("No line to cut");
+            return;
+        }
+        let line_text = lines[row].to_string();
+        let total_lines = lines.len();
+        let is_last_line = row == total_lines - 1;
+
+        // Select the entire line including its trailing newline, then cut via
+        // TextArea so the deletion is recorded in the undo history.
+        let tab = &mut self.tabs[self.active_tab];
+        if is_last_line && row > 0 {
+            // Last line: select from end of previous line through end of this line
+            tab.editor.move_cursor(tui_textarea::CursorMove::Jump(
+                to_u16_saturating(row - 1),
+                u16::MAX,
+            ));
+            tab.editor.start_selection();
+            tab.editor.move_cursor(tui_textarea::CursorMove::Jump(
+                to_u16_saturating(row),
+                u16::MAX,
+            ));
+        } else if total_lines == 1 {
+            // Only one line: select all text on it
+            tab.editor
+                .move_cursor(tui_textarea::CursorMove::Jump(to_u16_saturating(row), 0));
+            tab.editor.start_selection();
+            tab.editor.move_cursor(tui_textarea::CursorMove::End);
+        } else {
+            // Select from start of this line to start of next line
+            tab.editor
+                .move_cursor(tui_textarea::CursorMove::Jump(to_u16_saturating(row), 0));
+            tab.editor.start_selection();
+            tab.editor.move_cursor(tui_textarea::CursorMove::Jump(
+                to_u16_saturating(row + 1),
+                0,
+            ));
+        }
+        tab.editor.cut();
+
+        // Overwrite yank buffer and system clipboard with the clean line text
+        if let Some(clipboard) = self.clipboard.as_mut() {
+            let _ = clipboard.set_text(line_text.clone());
+        }
+        self.tabs[self.active_tab]
+            .editor
+            .set_yank_text(line_text);
+        self.on_editor_content_changed();
+        self.set_status("Cut line");
+    }
+
     pub(crate) fn cut_selection_to_clipboard(&mut self) {
         let Some(tab) = self.active_tab() else {
             return;
@@ -728,5 +785,53 @@ impl App {
                 ));
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn new_app(root: &std::path::Path) -> App {
+        App::new(root.to_path_buf()).expect("app should initialize")
+    }
+
+    #[test]
+    fn cut_line_removes_middle_line() {
+        let tmp = tempdir().expect("tempdir");
+        let root = tmp.path();
+        let file = root.join("test.txt");
+        fs::write(&file, "aaa\nbbb\nccc\n").expect("write");
+        let mut app = new_app(root);
+        app.open_file(file).expect("open");
+        // Move cursor to line 1 (bbb)
+        app.tabs[app.active_tab]
+            .editor
+            .move_cursor(tui_textarea::CursorMove::Jump(1, 0));
+        app.cut_line();
+        let lines = app.tabs[app.active_tab].editor.lines().to_vec();
+        assert_eq!(lines, vec!["aaa", "ccc", ""]);
+    }
+
+    #[test]
+    fn cut_line_removes_last_line() {
+        let tmp = tempdir().expect("tempdir");
+        let root = tmp.path();
+        let file = root.join("test.txt");
+        fs::write(&file, "aaa\nbbb\n").expect("write");
+        let mut app = new_app(root);
+        app.open_file(file).expect("open");
+        // Move cursor to last content line (index 2 is the empty trailing line)
+        app.tabs[app.active_tab]
+            .editor
+            .move_cursor(tui_textarea::CursorMove::Jump(2, 0));
+        app.cut_line();
+        let lines = app.tabs[app.active_tab].editor.lines().to_vec();
+        assert_eq!(lines, vec!["aaa", "bbb"]);
+        // Cursor should be clamped, not out of bounds
+        let (row, _) = app.tabs[app.active_tab].editor.cursor();
+        assert!(row < lines.len());
     }
 }

--- a/src/app/input_handlers.rs
+++ b/src/app/input_handlers.rs
@@ -536,6 +536,7 @@ impl App {
             }
             KeyAction::Copy => self.copy_selection_to_clipboard(),
             KeyAction::Cut => self.cut_selection_to_clipboard(),
+            KeyAction::CutLine => self.cut_line(),
             KeyAction::Paste => self.paste_from_clipboard(),
             KeyAction::ToggleComment => self.toggle_comment(),
             KeyAction::PageDown => self.page_down(),

--- a/src/keybinds.rs
+++ b/src/keybinds.rs
@@ -47,6 +47,7 @@ pub(crate) enum KeyAction {
     SelectAll,
     Copy,
     Cut,
+    CutLine,
     Paste,
     ToggleComment,
     PageDown,
@@ -118,6 +119,7 @@ impl KeyAction {
             KeyAction::SelectAll => "Select All",
             KeyAction::Copy => "Copy",
             KeyAction::Cut => "Cut",
+            KeyAction::CutLine => "Cut Line",
             KeyAction::Paste => "Paste",
             KeyAction::ToggleComment => "Toggle Comment",
             KeyAction::PageDown => "Page Down",
@@ -163,6 +165,7 @@ impl KeyAction {
             KeyAction::SelectAll,
             KeyAction::Copy,
             KeyAction::Cut,
+            KeyAction::CutLine,
             KeyAction::Paste,
             KeyAction::ToggleComment,
             KeyAction::PageDown,
@@ -532,6 +535,7 @@ impl KeyBindings {
         bind(KeyAction::SelectAll, "ctrl+a");
         bind(KeyAction::Copy, "ctrl+c");
         bind(KeyAction::Cut, "ctrl+x");
+        bind(KeyAction::CutLine, "ctrl+k");
         bind(KeyAction::Paste, "ctrl+v");
         bind(KeyAction::PageDown, "pagedown");
         bind(KeyAction::PageUp, "pageup");

--- a/src/ui/overlays.rs
+++ b/src/ui/overlays.rs
@@ -458,6 +458,7 @@ pub(crate) fn render_help(app: &mut App, frame: &mut Frame<'_>) {
                 (&kb.display_for(KeyAction::SelectAll), "select all"),
                 (&kb.display_for(KeyAction::Copy), "copy"),
                 (&kb.display_for(KeyAction::Cut), "cut"),
+                (&kb.display_for(KeyAction::CutLine), "cut line"),
                 (&kb.display_for(KeyAction::Paste), "paste"),
                 (&kb.display_for(KeyAction::ToggleComment), "toggle comment"),
             ],


### PR DESCRIPTION
Closes #7

## Summary
- Adds `CutLine` key action bound to `Ctrl+K` that cuts the entire current line to the clipboard
- Uses TextArea's native selection + cut so the operation is undoable
- Handles edge cases: last line, single-line files
- Adds `CutLine` to the help overlay and keybind editor

## Test plan
- [x] `cargo build` passes
- [x] `cargo test` passes (260 tests, 2 new: `cut_line_removes_middle_line`, `cut_line_removes_last_line`)
- [x] Manual: open file, place cursor mid-line, press Ctrl+K → full line cut, paste returns it

🤖 Generated with [Claude Code](https://claude.com/claude-code)