### PR TITLE
Fix pasted text getting auto-pair doubled

### DIFF
--- a/src/app/editor.rs
+++ b/src/app/editor.rs
@@ -263,6 +263,24 @@ impl App {
         }
     }
 
+    /// Handle a bracketed paste event from the terminal. Inserts text
+    /// directly into the editor, bypassing auto-pair logic.
+    pub(crate) fn handle_paste(&mut self, text: String) {
+        if text.is_empty() {
+            return;
+        }
+        if self.active_tab_mut().is_none() {
+            return;
+        }
+        let inserted = self
+            .active_tab_mut()
+            .is_some_and(|t| t.editor.insert_str(&text));
+        if inserted {
+            self.on_editor_content_changed();
+            self.set_status("Pasted");
+        }
+    }
+
     pub(crate) fn paste_from_clipboard(&mut self) {
         let mut from_system = false;
         if let Some(clipboard) = self.clipboard.as_mut() {


### PR DESCRIPTION
## Summary
- Enable bracketed paste mode (`EnableBracketedPaste`) so the terminal sends pasted content as a single `Event::Paste` event instead of individual keystrokes
- Handle `Event::Paste` in the event loop to insert text directly via `insert_str`, bypassing auto-pair logic
- Disable bracketed paste on shutdown and panic for clean terminal restore

Without this, pasting text containing `"`, `{`, `[`, or `'` through the terminal (especially over SSH) triggers auto-pair insertion, doubling each character.

Fixes #9

## Test plan
- [ ] Paste `{"key": "value", "arr": [1, 2]}` into a JSON file — no doubled quotes/brackets
- [ ] Ctrl+V paste still works as before
- [ ] Auto-pair still works when typing individual characters
- [ ] Terminal restores cleanly on exit and on panic

🤖 Generated with [Claude Code](https://claude.com/claude-code)