### PR TITLE
Add cursor navigation to prompt inputs

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -109,6 +109,7 @@ pub(crate) struct App {
     pub(crate) tab_rects: Vec<(Rect, Rect)>,
     pub(crate) context_menu: ContextMenuState,
     pub(crate) prompt: Option<PromptState>,
+    pub(crate) prompt_rect: Rect,
     pub(crate) clipboard: Option<Clipboard>,
     pub(crate) editor_context_menu_open: bool,
     pub(crate) editor_context_menu_index: usize,

--- a/src/app/core.rs
+++ b/src/app/core.rs
@@ -78,6 +78,7 @@ impl App {
                 rect: Rect::default(),
             },
             prompt: None,
+            prompt_rect: Rect::default(),
             clipboard: Clipboard::new().ok(),
             editor_context_menu_open: false,
             editor_context_menu_index: 0,
@@ -424,6 +425,7 @@ impl App {
         self.prompt = Some(PromptState {
             title: "Find in file (regex)".to_string(),
             value: String::new(),
+            cursor: 0,
             mode: PromptMode::FindInFile,
         });
     }
@@ -432,6 +434,7 @@ impl App {
         self.prompt = Some(PromptState {
             title: "Search in files (ripgrep)".to_string(),
             value: String::new(),
+            cursor: 0,
             mode: PromptMode::FindInProject,
         });
     }
@@ -440,6 +443,7 @@ impl App {
         self.prompt = Some(PromptState {
             title: "Go to line".to_string(),
             value: String::new(),
+            cursor: 0,
             mode: PromptMode::GoToLine,
         });
     }

--- a/src/app/file_tree.rs
+++ b/src/app/file_tree.rs
@@ -382,6 +382,7 @@ impl App {
                     self.prompt = Some(PromptState {
                         title: format!("Replace '{}' with", value),
                         value: String::new(),
+                        cursor: 0,
                         mode: PromptMode::ReplaceInFile { search: value },
                     });
                 }
@@ -443,6 +444,7 @@ impl App {
                         relative_path(&self.root, &parent).display()
                     ),
                     value: String::new(),
+                    cursor: 0,
                     mode: PromptMode::NewFile { parent },
                 });
             }
@@ -458,6 +460,7 @@ impl App {
                         relative_path(&self.root, &parent).display()
                     ),
                     value: String::new(),
+                    cursor: 0,
                     mode: PromptMode::NewFolder { parent },
                 });
             }
@@ -470,9 +473,11 @@ impl App {
                     .file_name()
                     .map(|s| s.to_string_lossy().to_string())
                     .unwrap_or_default();
+                let cursor = default_name.len();
                 self.prompt = Some(PromptState {
                     title: "Rename to".to_string(),
                     value: default_name,
+                    cursor,
                     mode: PromptMode::Rename { target },
                 });
             }

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -121,7 +121,7 @@ impl App {
             return Ok(());
         }
 
-        // Modal states: allow left-click to dismiss, block everything else
+        // Modal states: handle prompt clicks or dismiss on click outside
         if self.prompt.is_some()
             || matches!(
                 self.pending,
@@ -132,6 +132,17 @@ impl App {
                 .is_some_and(|t| t.recovery_prompt_open || t.conflict_prompt_open)
         {
             if matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left)) {
+                // If prompt is open and click is inside the input area, move cursor
+                if self.prompt.is_some()
+                    && inside(mouse.column, mouse.row, self.prompt_rect)
+                {
+                    let inner_x =
+                        mouse.column.saturating_sub(self.prompt_rect.x + 1) as usize;
+                    if let Some(prompt) = self.prompt.as_mut() {
+                        prompt.cursor = inner_x.min(prompt.value.len());
+                    }
+                    return Ok(());
+                }
                 // Dismiss the modal on click outside (Esc-equivalent)
                 if self.prompt.is_some() {
                     self.prompt = None;

--- a/src/app/input_handlers.rs
+++ b/src/app/input_handlers.rs
@@ -58,11 +58,36 @@ impl App {
                 self.apply_prompt(mode, value)?;
             }
             (_, KeyCode::Backspace) => {
-                prompt.value.pop();
+                if prompt.cursor > 0 {
+                    prompt.value.remove(prompt.cursor - 1);
+                    prompt.cursor -= 1;
+                }
+            }
+            (_, KeyCode::Delete) => {
+                if prompt.cursor < prompt.value.len() {
+                    prompt.value.remove(prompt.cursor);
+                }
+            }
+            (_, KeyCode::Left) => {
+                if prompt.cursor > 0 {
+                    prompt.cursor -= 1;
+                }
+            }
+            (_, KeyCode::Right) => {
+                if prompt.cursor < prompt.value.len() {
+                    prompt.cursor += 1;
+                }
+            }
+            (_, KeyCode::Home) => {
+                prompt.cursor = 0;
+            }
+            (_, KeyCode::End) => {
+                prompt.cursor = prompt.value.len();
             }
             (_, KeyCode::Char(c)) => {
                 if !key.modifiers.contains(KeyModifiers::CONTROL) {
-                    prompt.value.push(c);
+                    prompt.value.insert(prompt.cursor, c);
+                    prompt.cursor += 1;
                 }
             }
             _ => {}

--- a/src/types.rs
+++ b/src/types.rs
@@ -46,6 +46,7 @@ pub(crate) enum CommandAction {
 pub(crate) struct PromptState {
     pub(crate) title: String,
     pub(crate) value: String,
+    pub(crate) cursor: usize,
     pub(crate) mode: PromptMode,
 }
 

--- a/src/ui/overlays.rs
+++ b/src/ui/overlays.rs
@@ -592,16 +592,26 @@ pub(crate) fn render_prompt(app: &mut App, frame: &mut Frame<'_>) {
     let Some(prompt) = app.prompt.as_ref() else {
         return;
     };
-    let theme = app.active_theme();
+    let title = prompt.title.clone();
+    let value = prompt.value.clone();
+    let cursor_pos = prompt.cursor;
+    let theme = app.active_theme().clone();
     let area = centered_rect(60, 20, frame.area());
+    app.prompt_rect = area;
     frame.render_widget(Clear, area);
-    let input = Paragraph::new(prompt.value.clone()).block(
-        themed_block(theme)
-            .title(prompt.title.as_str())
+    let input = Paragraph::new(value).block(
+        themed_block(&theme)
+            .title(title.as_str())
             .border_style(Style::default().fg(theme.accent))
             .style(Style::default().bg(theme.bg_alt).fg(theme.fg)),
     );
     frame.render_widget(input, area);
+    // Show a visible cursor at the current position in the input text
+    let cursor_x = area.x + 1 + cursor_pos as u16;
+    let cursor_y = area.y + 1;
+    if cursor_x < area.right() {
+        frame.set_cursor_position((cursor_x, cursor_y));
+    }
 }
 
 fn render_dialog(


### PR DESCRIPTION
## Summary
- Track cursor position in `PromptState` with Left/Right, Home/End, Delete key support
- Insert characters at cursor position instead of always appending
- Show a visible blinking cursor at the current position
- Mouse click inside the prompt repositions the cursor; click outside dismisses

Closes #10

## Test plan
- [x] Rename a file — cursor starts at end of name, arrow keys move it, typing inserts at cursor
- [x] Backspace/Delete work at cursor position
- [x] Home/End jump to start/end
- [x] Click inside the prompt moves cursor to click position
- [x] Click outside the prompt dismisses it
- [x] New file/folder/find prompts start with cursor at position 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)