### PR TITLE
Fix file tree click targeting wrong file after scrolling

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -7,6 +7,7 @@ use std::time::Instant;
 use arboard::Clipboard;
 use notify::RecommendedWatcher;
 use ratatui::layout::Rect;
+use ratatui::widgets::ListState;
 
 use crate::keybinds::{KeyAction, KeyBind, KeyBindings};
 use crate::lsp_client::{LspClient, LspCompletionItem};
@@ -80,6 +81,7 @@ pub(crate) struct App {
     pub(crate) root: PathBuf,
     pub(crate) tree: Vec<TreeItem>,
     pub(crate) selected: usize,
+    pub(crate) tree_state: ListState,
     pub(crate) expanded: HashSet<PathBuf>,
     pub(crate) focus: Focus,
     pub(crate) tabs: Vec<Tab>,

--- a/src/app/core.rs
+++ b/src/app/core.rs
@@ -1,4 +1,5 @@
 use super::{App, CompletionState, ContextMenuState, KeybindEditorState, SearchResultsState};
+use ratatui::widgets::ListState;
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io;
@@ -43,6 +44,7 @@ impl App {
             root,
             tree: Vec::new(),
             selected: 0,
+            tree_state: ListState::default(),
             expanded,
             focus: Focus::Tree,
             tabs: Vec::new(),

--- a/src/app/input_handlers.rs
+++ b/src/app/input_handlers.rs
@@ -899,7 +899,7 @@ impl App {
         if y < start || y >= end {
             return None;
         }
-        let idx = (y - start) as usize;
+        let idx = (y - start) as usize + self.tree_state.offset();
         if idx < self.tree.len() {
             Some(idx)
         } else {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -10,7 +10,7 @@ use ratatui::Frame;
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph, Wrap};
+use ratatui::widgets::{Block, Borders, Clear, List, ListItem, Paragraph, Wrap};
 use unicode_width::UnicodeWidthStr;
 
 use crate::app::App;
@@ -140,8 +140,7 @@ pub(crate) fn draw(app: &mut App, frame: &mut Frame<'_>) {
                 )))
             })
             .collect();
-        let mut tree_state = ListState::default();
-        tree_state.select(Some(app.selected));
+        app.tree_state.select(Some(app.selected));
         let tree = List::new(tree_items)
             .highlight_style(
                 Style::default()
@@ -156,7 +155,7 @@ pub(crate) fn draw(app: &mut App, frame: &mut Frame<'_>) {
                     .border_style(Style::default().fg(left_border))
                     .style(Style::default().bg(theme.bg_alt).fg(theme.fg)),
             );
-        frame.render_stateful_widget(tree, tree_area, &mut tree_state);
+        frame.render_stateful_widget(tree, tree_area, &mut app.tree_state);
         if app.files_view_open && app.divider_rect.width > 0 {
             let divider =
                 Paragraph::new("│").style(Style::default().fg(theme.border).bg(theme.bg_alt));


### PR DESCRIPTION
## Summary
- Persist `ListState` on `App` instead of recreating it every frame, so the tree scroll offset is maintained between renders
- Use the persisted offset in `tree_index_from_mouse` so clicks correctly map to the visible item
- Fixes both the wrong-file-on-click bug and the scroll-jumps-to-top issue

Closes #11

## Test plan
- [x] Scroll down in a large file tree, click a file — correct file opens
- [x] Scroll position stays put after clicking a file
- [x] Keyboard navigation still works correctly
- [x] Mouse scroll in tree still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)