### PR TITLE
Add TreeExpandRecursive/CollapseRecursive KeyActions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,14 @@ Core model remains the same:
   - `Ctrl+Shift+C` — collapse all folders globally
   - `Delete` — delete selected item
 
+## Editor Features
+
+- **Gutter line selection** — click the gutter to select a line, drag to select multiple lines
+- **Cut line** — Ctrl+K cuts the entire current line
+- **Auto-pair insertion** — automatically pairs `()`, `[]`, `{}`, `""`, `''`
+- **Bracketed paste** — multi-line paste without auto-pair doubling
+- **Inline ghost completion** — LSP ghost text shown inline, Tab to accept
+
 ## Themes
 
 `themes/*.json` — Each file defines background, foreground, accent, selection, border, and UI element colors. Parsed via `ThemeFile` struct with serde. Fallback to built-in dark theme if no files found.

--- a/src/app/input_handlers.rs
+++ b/src/app/input_handlers.rs
@@ -305,12 +305,6 @@ impl App {
             (KeyModifiers::NONE, KeyCode::Left) | (KeyModifiers::NONE, KeyCode::Char('h')) => {
                 self.tree_collapse_or_parent();
             }
-            (KeyModifiers::SHIFT, KeyCode::Right) => {
-                self.tree_expand_recursive()?;
-            }
-            (KeyModifiers::SHIFT, KeyCode::Left) => {
-                self.tree_collapse_recursive()?;
-            }
             _ => {}
         }
         Ok(())
@@ -510,6 +504,12 @@ impl App {
             KeyAction::TreeCollapseAll => {
                 self.tree_collapse_all()?;
                 self.set_status("Collapsed all folders");
+            }
+            KeyAction::TreeExpandRecursive => {
+                self.tree_expand_recursive()?;
+            }
+            KeyAction::TreeCollapseRecursive => {
+                self.tree_collapse_recursive()?;
             }
             // Editor
             KeyAction::GoToDefinition => {

--- a/src/keybinds.rs
+++ b/src/keybinds.rs
@@ -30,6 +30,8 @@ pub(crate) enum KeyAction {
     ToggleWordWrap,
     TreeExpandAll,
     TreeCollapseAll,
+    TreeExpandRecursive,
+    TreeCollapseRecursive,
     // Editor
     GoToDefinition,
     FoldToggle,
@@ -80,6 +82,8 @@ impl KeyAction {
                 | KeyAction::ToggleWordWrap
                 | KeyAction::TreeExpandAll
                 | KeyAction::TreeCollapseAll
+                | KeyAction::TreeExpandRecursive
+                | KeyAction::TreeCollapseRecursive
         )
     }
 
@@ -107,6 +111,8 @@ impl KeyAction {
             KeyAction::ToggleWordWrap => "Toggle Word Wrap",
             KeyAction::TreeExpandAll => "Expand All Folders",
             KeyAction::TreeCollapseAll => "Collapse All Folders",
+            KeyAction::TreeExpandRecursive => "Expand Dir Recursive",
+            KeyAction::TreeCollapseRecursive => "Collapse Dir Recursive",
             KeyAction::GoToDefinition => "Go to Definition",
             KeyAction::FoldToggle => "Toggle Fold",
             KeyAction::FoldAllToggle => "Toggle Fold All",
@@ -155,6 +161,8 @@ impl KeyAction {
             KeyAction::ToggleWordWrap,
             KeyAction::TreeExpandAll,
             KeyAction::TreeCollapseAll,
+            KeyAction::TreeExpandRecursive,
+            KeyAction::TreeCollapseRecursive,
             KeyAction::GoToDefinition,
             KeyAction::FoldToggle,
             KeyAction::FoldAllToggle,
@@ -520,6 +528,8 @@ impl KeyBindings {
         bind(KeyAction::ToggleWordWrap, "f6");
         bind(KeyAction::TreeExpandAll, "ctrl+shift+e");
         bind(KeyAction::TreeCollapseAll, "ctrl+shift+c");
+        bind(KeyAction::TreeExpandRecursive, "shift+right");
+        bind(KeyAction::TreeCollapseRecursive, "shift+left");
 
         // Editor
         bind(KeyAction::GoToDefinition, "ctrl+d");

--- a/src/ui/overlays.rs
+++ b/src/ui/overlays.rs
@@ -491,8 +491,8 @@ pub(crate) fn render_help(app: &mut App, frame: &mut Frame<'_>) {
         ),
         help_keybind_line(
             &[
-                ("Shift+Right", "expand recursive"),
-                ("Shift+Left", "collapse recursive"),
+                (&kb.display_for(KeyAction::TreeExpandRecursive), "expand recursive"),
+                (&kb.display_for(KeyAction::TreeCollapseRecursive), "collapse recursive"),
             ],
             key_s,
             desc_s,


### PR DESCRIPTION
## Summary
- Move Shift+Right/Left recursive tree expand/collapse from hardcoded key handling into the `KeyAction` system, making them customizable via the keybind editor
- Update help overlay to use `display_for()` for recursive expand/collapse instead of hardcoded strings
- Add Editor Features section to CLAUDE.md documenting gutter selection, cut line, auto-pair, bracketed paste, and ghost completion

## Test plan
- [x] `cargo build` — no errors
- [x] `cargo test` — all 272 tests pass
- [x] Verify keybind editor shows TreeExpandRecursive and TreeCollapseRecursive
- [x] Verify Shift+Right/Left still work as defaults for recursive expand/collapse
- [x] Verify help overlay reflects customized keybinds for recursive expand/collapse

🤖 Generated with [Claude Code](https://claude.com/claude-code)